### PR TITLE
Use queue for stat names

### DIFF
--- a/harness-action_subscriber.gemspec
+++ b/harness-action_subscriber.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
 
   spec.add_runtime_dependency "harness", ">= 2.0.0"
-  spec.add_runtime_dependency "action_subscriber", ">= 1.0.2"
+  spec.add_runtime_dependency "action_subscriber", ">= 2.0.0"
 end

--- a/lib/harness/action_subscriber.rb
+++ b/lib/harness/action_subscriber.rb
@@ -16,6 +16,6 @@ end
 
 ::ActiveSupport::Notifications.subscribe "process_event.action_subscriber" do |*args|
   event = ::ActiveSupport::Notifications::Event.new(*args)
-  event_name = event.payload[:routing_key].gsub '.', '-'
+  event_name = event.payload[:queue].gsub '.', '-'
   ::Harness.timing "action_subscriber.process_event.#{event_name}", event.duration
 end


### PR DESCRIPTION
This goes along with mxenabled/action_subscriber#44

I'm not sure why I originally decided to use the `routing_key` to name the timer statistic. That value is controlled by the publisher and in general I don't think subscribers should be introspecting it.

/cc @quixoten @liveh2o @brianstien @abrandoned 
